### PR TITLE
Use more robust "custom" handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,12 @@ const [isOpen, setIsOpen] = useState<boolean>(false);
 
 useEffect(() => {
   function handleKeyDown(e: KeyboardEvent) {
-    if (e.metaKey && e.key === "k") {
+    if (
+      (navigator?.platform?.toLowerCase().includes("mac")
+        ? e.metaKey
+        : e.ctrlKey) &&
+      e.key === "k"
+    ) {
       e.preventDefault();
       e.stopPropagation();
 


### PR DESCRIPTION
Using the baseline from your hook as the "custom" hook. 

I blindly copy + pasted the custom hook and got bit on windows 😭