### PR TITLE
update: logout icon in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ const Example = () => {
           {
             id: "log-out",
             children: "Log out",
-            icon: "ArrowLeftIcon",
+            icon: "ArrowRightOnRectangleIcon",
             onClick: () => {
               alert("Logging out...");
             },

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ const Example = () => {
           {
             id: "log-out",
             children: "Log out",
-            icon: "LogoutIcon",
+            icon: "ArrowLeftIcon",
             onClick: () => {
               alert("Logging out...");
             },


### PR DESCRIPTION
I have updated the icon property for the **log-out** object in the README example. The original value was `LogoutIcon`, which was causing an issue: `"Type "LogoutIcon"' is not assignable to type 'FC | IconName'.` To resolve this, I replaced `LogoutIcon` with `ArrowLeftIcon`, a valid icon type that should not cause any compatibility issues.